### PR TITLE
fix: resolve mypy type errors and enable blocking type checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: ruff check .
 
       - name: Type check with mypy
-        run: mypy src --ignore-missing-imports || echo "::warning::mypy found type errors (non-blocking)"
+        run: mypy src --ignore-missing-imports
 
   test:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,5 +18,3 @@ repos:
         args: [--ignore-missing-imports]
         additional_dependencies: []
         verbose: true
-        # TODO: Remove this once mypy errors are fixed (see #37)
-        stages: [manual]

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -671,6 +671,13 @@ def create_app() -> Dash:
         if _current_candle is not None:
             candles = candles + [_current_candle]
 
+        opens: list[float] = []
+        highs: list[float] = []
+        lows: list[float] = []
+        closes: list[float] = []
+        x_vals: list[int] = []
+        y_range: list[float] | None = None
+
         if candles:
             opens = [c.open for c in candles]
             highs = [c.high for c in candles]
@@ -684,9 +691,6 @@ def create_app() -> Dash:
             y_max = max(all_prices)
             y_padding = (y_max - y_min) * 0.1 if y_max > y_min else 10
             y_range = [y_min - y_padding, y_max + y_padding]
-        else:
-            opens = highs = lows = closes = x_vals = []
-            y_range = None
 
         price_chart = {
             "data": [

--- a/src/features/extractor.py
+++ b/src/features/extractor.py
@@ -138,4 +138,4 @@ class FeatureExtractor:
         # Compute standard deviation
         mean = sum(changes) / len(changes)
         variance = sum((x - mean) ** 2 for x in changes) / len(changes)
-        return variance**0.5
+        return float(variance**0.5)

--- a/src/ingest/websocket_client.py
+++ b/src/ingest/websocket_client.py
@@ -39,7 +39,7 @@ class CoinbaseWebSocketClient:
         self.symbol = symbol
         self.on_update = on_update
         self._running = False
-        self._ws: websockets.WebSocketClientProtocol | None = None
+        self._ws: websockets.ClientConnection | None = None
 
     async def start(self) -> None:
         """Start the WebSocket client with reconnection logic."""
@@ -85,6 +85,8 @@ class CoinbaseWebSocketClient:
 
             # Process messages
             async for message in ws:
+                if isinstance(message, bytes):
+                    message = message.decode("utf-8")
                 await self._handle_message(message)
 
     async def _handle_message(self, message: str) -> None:


### PR DESCRIPTION
## Summary
- Fixed 4 mypy type errors across 3 files:
  - `extractor.py`: Add explicit `float` cast to variance calculation return
  - `websocket_client.py`: Use `ClientConnection` type, decode bytes messages  
  - `app.py`: Define OHLC list variables before conditional assignment
- Re-enabled mypy as blocking in CI workflow
- Re-enabled mypy in pre-commit hooks (removed `stages: [manual]`)

Closes #37 (mypy errors AC)

## Test plan
- [x] `mypy src --ignore-missing-imports` passes locally
- [x] All 37 existing tests pass
- [x] `pre-commit run --all-files` passes