### PR TITLE
feat: add Iceberg catalog with Postgres backend and table schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,23 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: localdev
+          POSTGRES_DB: iceberg
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      ICEBERG_CATALOG_URI: postgresql+psycopg2://postgres:localdev@localhost:5432/iceberg
+      ICEBERG_WAREHOUSE: file:///tmp/warehouse
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -37,12 +37,19 @@ open http://localhost:8050
 # Install with dev dependencies
 pip install -e ".[dev]"
 
+# Start Postgres for Iceberg catalog (requires Docker)
+docker compose up -d
+
+# Set environment variables for local development
+export ICEBERG_CATALOG_URI="postgresql+psycopg2://postgres:localdev@localhost:5433/iceberg"
+export ICEBERG_WAREHOUSE="file://data/warehouse"
+
 # Linting/formatting
 black .
 ruff check .
 mypy src/
 
-# Tests
+# Tests (requires Postgres running)
 pytest -v
 ```
 
@@ -53,6 +60,7 @@ src/
   ingest/       # WebSocket client + order book cache
   features/     # Feature extraction + labeling
   model/        # OnlineClassifier (SGDClassifier)
+  storage/      # Iceberg catalog + table schemas
   dashboard/    # Plotly Dash app
 docs/           # Architecture, requirements, design docs
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: quotewatch-postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: localdev
+      POSTGRES_DB: iceberg
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/docs/design/data-layer.md
+++ b/docs/design/data-layer.md
@@ -439,7 +439,7 @@ Configuration is driven by environment variables (`ICEBERG_CATALOG_URI`, `ICEBER
 
 ## 8. Open Questions
 
-1. **Exact depth?** 10 or 20 levels? (Leaning toward 10 to start)
+1. ~~**Exact depth?**~~ **Resolved:** 10 levels to start
 2. **Retention policy?** How long to keep data? (Maybe 30 days to start)
 3. **GCS bucket setup?** Need to create bucket, set up auth for Cloud Run
 4. ~~**Catalog in prod?**~~ **Resolved:** Postgres everywhere (Docker locally, Cloud SQL in prod)
@@ -505,3 +505,41 @@ Configuration is driven by environment variables (`ICEBERG_CATALOG_URI`, `ICEBER
 | `tests/test_trade_buffer.py` | Create | Tests |
 | `tests/test_writer.py` | Create | Tests |
 | `tests/test_reader.py` | Create | Tests |
+
+---
+
+## 11. Implementation Progress
+
+### Step 3: Iceberg Catalog + Table Schemas (Issue #41)
+
+**Status:** Complete
+
+**What was implemented:**
+
+1. **Docker setup** (`docker-compose.yml`)
+   - Postgres 16 container for Iceberg catalog
+   - Health checks for reliable startup
+   - Persistent volume for data
+
+2. **Dependencies** (`pyproject.toml`)
+   - `pyiceberg[sql-postgres]>=0.7.0`
+   - `psycopg2-binary>=2.9`
+
+3. **Storage package** (`src/storage/`)
+   - `catalog.py`: Factory function loading from `ICEBERG_CATALOG_URI` and `ICEBERG_WAREHOUSE` env vars
+   - `schemas.py`: All 4 table schemas with flattened column naming
+
+4. **Table schemas implemented:**
+   - `raw_orderbook`: 10 levels of bids/asks with `bid_N_price`, `bid_N_size` naming
+   - `raw_trades`: trade_id, price, size, side with decimal(18,8) precision
+   - `features`: spread_bps, imbalance, depth, volatility, trade_imbalance
+   - `predictions`: model_id, prediction, probability, label, labeled_at_ms
+
+5. **CI/CD** (`.github/workflows/ci.yml`)
+   - Postgres 16 service container
+   - Environment variables for catalog connection
+
+6. **Integration tests** (`tests/storage/test_catalog.py`)
+   - Catalog connectivity
+   - Table creation and idempotency
+   - Schema validation for all 4 tables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ dependencies = [
     "plotly>=5.18",
     "dash>=2.14",
     "gunicorn>=21.0",
+    "pyiceberg[sql-postgres]>=0.7.0",
+    "psycopg2-binary>=2.9",
 ]
 
 [project.optional-dependencies]

--- a/src/storage/__init__.py
+++ b/src/storage/__init__.py
@@ -1,0 +1,21 @@
+"""Storage package for Iceberg data lake operations."""
+
+from src.storage.catalog import get_catalog
+from src.storage.schemas import (
+    FEATURES_SCHEMA,
+    NAMESPACE,
+    PREDICTIONS_SCHEMA,
+    RAW_ORDERBOOK_SCHEMA,
+    RAW_TRADES_SCHEMA,
+    create_tables,
+)
+
+__all__ = [
+    "get_catalog",
+    "create_tables",
+    "NAMESPACE",
+    "RAW_ORDERBOOK_SCHEMA",
+    "RAW_TRADES_SCHEMA",
+    "FEATURES_SCHEMA",
+    "PREDICTIONS_SCHEMA",
+]

--- a/src/storage/catalog.py
+++ b/src/storage/catalog.py
@@ -1,0 +1,38 @@
+"""Iceberg catalog configuration and factory function."""
+
+import os
+
+from pyiceberg.catalog.sql import SqlCatalog
+
+
+def get_catalog(name: str = "default") -> SqlCatalog:
+    """Load an Iceberg SQL catalog from environment variables.
+
+    Environment variables:
+        ICEBERG_CATALOG_URI: PostgreSQL connection string
+            (e.g., postgresql+psycopg2://postgres:localdev@localhost:5432/iceberg)
+        ICEBERG_WAREHOUSE: Warehouse path for table data
+            (e.g., file://data/warehouse or gs://bucket/warehouse)
+
+    Args:
+        name: Catalog name identifier. Defaults to "default".
+
+    Returns:
+        Configured Iceberg SQL catalog.
+
+    Raises:
+        ValueError: If required environment variables are not set.
+    """
+    catalog_uri = os.environ.get("ICEBERG_CATALOG_URI")
+    warehouse = os.environ.get("ICEBERG_WAREHOUSE")
+
+    if not catalog_uri:
+        raise ValueError("ICEBERG_CATALOG_URI environment variable is required")
+    if not warehouse:
+        raise ValueError("ICEBERG_WAREHOUSE environment variable is required")
+
+    return SqlCatalog(
+        name,
+        uri=catalog_uri,
+        warehouse=warehouse,
+    )

--- a/src/storage/schemas.py
+++ b/src/storage/schemas.py
@@ -1,0 +1,167 @@
+"""Iceberg table schema definitions for market data storage.
+
+Schema conventions:
+- Price/size columns use decimal(18,8) to match Coinbase string precision
+- Timestamps use bigint (milliseconds since epoch) from exchange
+- received_at uses timestamp for when we received the data
+- Order book levels are flattened: bid_0_price, bid_0_size, bid_1_price, etc.
+"""
+
+from pyiceberg.catalog import Catalog
+from pyiceberg.schema import Schema
+from pyiceberg.types import (
+    DecimalType,
+    FloatType,
+    IntegerType,
+    LongType,
+    NestedField,
+    StringType,
+    TimestampType,
+)
+
+NAMESPACE = "quotewatch"
+ORDER_BOOK_DEPTH = 10
+
+
+def _build_orderbook_fields() -> list[NestedField]:
+    """Build flattened order book schema fields for 10 levels of bids and asks."""
+    fields: list[NestedField] = [
+        NestedField(
+            field_id=1, name="timestamp_ms", field_type=LongType(), required=True
+        ),
+        NestedField(field_id=2, name="symbol", field_type=StringType(), required=True),
+    ]
+
+    field_id = 3
+    # Bid levels: bid_0_price, bid_0_size, bid_1_price, bid_1_size, ...
+    for i in range(ORDER_BOOK_DEPTH):
+        fields.append(
+            NestedField(
+                field_id=field_id,
+                name=f"bid_{i}_price",
+                field_type=DecimalType(precision=18, scale=8),
+                required=False,
+            )
+        )
+        field_id += 1
+        fields.append(
+            NestedField(
+                field_id=field_id,
+                name=f"bid_{i}_size",
+                field_type=DecimalType(precision=18, scale=8),
+                required=False,
+            )
+        )
+        field_id += 1
+
+    # Ask levels: ask_0_price, ask_0_size, ask_1_price, ask_1_size, ...
+    for i in range(ORDER_BOOK_DEPTH):
+        fields.append(
+            NestedField(
+                field_id=field_id,
+                name=f"ask_{i}_price",
+                field_type=DecimalType(precision=18, scale=8),
+                required=False,
+            )
+        )
+        field_id += 1
+        fields.append(
+            NestedField(
+                field_id=field_id,
+                name=f"ask_{i}_size",
+                field_type=DecimalType(precision=18, scale=8),
+                required=False,
+            )
+        )
+        field_id += 1
+
+    fields.append(
+        NestedField(
+            field_id=field_id,
+            name="received_at",
+            field_type=TimestampType(),
+            required=True,
+        )
+    )
+
+    return fields
+
+
+RAW_ORDERBOOK_SCHEMA = Schema(*_build_orderbook_fields())
+
+RAW_TRADES_SCHEMA = Schema(
+    NestedField(field_id=1, name="trade_id", field_type=StringType(), required=True),
+    NestedField(field_id=2, name="timestamp_ms", field_type=LongType(), required=True),
+    NestedField(field_id=3, name="symbol", field_type=StringType(), required=True),
+    NestedField(
+        field_id=4,
+        name="price",
+        field_type=DecimalType(precision=18, scale=8),
+        required=True,
+    ),
+    NestedField(
+        field_id=5,
+        name="size",
+        field_type=DecimalType(precision=18, scale=8),
+        required=True,
+    ),
+    NestedField(field_id=6, name="side", field_type=StringType(), required=True),
+    NestedField(
+        field_id=7, name="received_at", field_type=TimestampType(), required=True
+    ),
+)
+
+FEATURES_SCHEMA = Schema(
+    NestedField(field_id=1, name="timestamp_ms", field_type=LongType(), required=True),
+    NestedField(field_id=2, name="symbol", field_type=StringType(), required=True),
+    NestedField(field_id=3, name="spread_bps", field_type=FloatType(), required=False),
+    NestedField(field_id=4, name="imbalance", field_type=FloatType(), required=False),
+    NestedField(field_id=5, name="depth", field_type=FloatType(), required=False),
+    NestedField(field_id=6, name="volatility", field_type=FloatType(), required=False),
+    NestedField(
+        field_id=7, name="trade_imbalance", field_type=FloatType(), required=False
+    ),
+)
+
+PREDICTIONS_SCHEMA = Schema(
+    NestedField(field_id=1, name="timestamp_ms", field_type=LongType(), required=True),
+    NestedField(field_id=2, name="symbol", field_type=StringType(), required=True),
+    NestedField(field_id=3, name="model_id", field_type=StringType(), required=True),
+    NestedField(field_id=4, name="prediction", field_type=IntegerType(), required=True),
+    NestedField(field_id=5, name="probability", field_type=FloatType(), required=True),
+    NestedField(field_id=6, name="label", field_type=IntegerType(), required=False),
+    NestedField(
+        field_id=7, name="labeled_at_ms", field_type=LongType(), required=False
+    ),
+)
+
+
+def create_tables(catalog: Catalog) -> None:
+    """Create all Iceberg tables in the catalog.
+
+    This function is idempotent - it will not fail if tables already exist.
+
+    Args:
+        catalog: Iceberg catalog to create tables in.
+    """
+    # Create namespace if it doesn't exist
+    try:
+        catalog.create_namespace(NAMESPACE)
+    except Exception:
+        # Namespace already exists
+        pass
+
+    table_schemas = {
+        "raw_orderbook": RAW_ORDERBOOK_SCHEMA,
+        "raw_trades": RAW_TRADES_SCHEMA,
+        "features": FEATURES_SCHEMA,
+        "predictions": PREDICTIONS_SCHEMA,
+    }
+
+    for table_name, schema in table_schemas.items():
+        identifier = f"{NAMESPACE}.{table_name}"
+        try:
+            catalog.create_table(identifier=identifier, schema=schema)
+        except Exception:
+            # Table already exists
+            pass

--- a/tests/storage/__init__.py
+++ b/tests/storage/__init__.py
@@ -1,0 +1,1 @@
+"""Storage integration tests."""

--- a/tests/storage/test_catalog.py
+++ b/tests/storage/test_catalog.py
@@ -1,0 +1,330 @@
+"""Integration tests for Iceberg catalog and table schemas.
+
+These tests require a running Postgres instance. In CI, this is provided
+by the GitHub Actions service container. Locally, run:
+    docker-compose up -d
+"""
+
+import os
+
+import pytest
+
+from src.storage.catalog import get_catalog
+from src.storage.schemas import (
+    NAMESPACE,
+    ORDER_BOOK_DEPTH,
+    create_tables,
+)
+
+
+@pytest.fixture(scope="module")
+def catalog():
+    """Provide catalog fixture, skip if Postgres not available."""
+    if not os.environ.get("ICEBERG_CATALOG_URI"):
+        pytest.skip("ICEBERG_CATALOG_URI not set - skipping integration tests")
+    return get_catalog("test")
+
+
+class TestGetCatalog:
+    """Tests for the get_catalog factory function."""
+
+    def test_get_catalog_raises_without_uri(self, monkeypatch):
+        """get_catalog raises ValueError when ICEBERG_CATALOG_URI is not set."""
+        # GIVEN environment without ICEBERG_CATALOG_URI
+        monkeypatch.delenv("ICEBERG_CATALOG_URI", raising=False)
+        monkeypatch.setenv("ICEBERG_WAREHOUSE", "file:///tmp/warehouse")
+
+        # WHEN we call get_catalog
+        # THEN it raises ValueError
+        with pytest.raises(ValueError, match="ICEBERG_CATALOG_URI"):
+            get_catalog()
+
+    def test_get_catalog_raises_without_warehouse(self, monkeypatch):
+        """get_catalog raises ValueError when ICEBERG_WAREHOUSE is not set."""
+        # GIVEN environment without ICEBERG_WAREHOUSE
+        monkeypatch.setenv(
+            "ICEBERG_CATALOG_URI",
+            "postgresql+psycopg2://postgres:localdev@localhost:5432/iceberg",
+        )
+        monkeypatch.delenv("ICEBERG_WAREHOUSE", raising=False)
+
+        # WHEN we call get_catalog
+        # THEN it raises ValueError
+        with pytest.raises(ValueError, match="ICEBERG_WAREHOUSE"):
+            get_catalog()
+
+    def test_get_catalog_connects_to_postgres(self, catalog):
+        """get_catalog successfully connects to Postgres."""
+        # GIVEN a configured catalog
+        # WHEN we list namespaces
+        namespaces = catalog.list_namespaces()
+
+        # THEN it returns a list (possibly empty)
+        assert isinstance(namespaces, list)
+
+
+class TestCreateTables:
+    """Tests for table creation."""
+
+    def test_create_tables_creates_namespace(self, catalog):
+        """create_tables creates the quotewatch namespace."""
+        # GIVEN a catalog
+        # WHEN we create tables
+        create_tables(catalog)
+
+        # THEN the namespace exists
+        namespaces = catalog.list_namespaces()
+        assert (NAMESPACE,) in namespaces
+
+    def test_create_tables_creates_all_four_tables(self, catalog):
+        """create_tables creates raw_orderbook, raw_trades, features, predictions."""
+        # GIVEN a catalog with tables created
+        create_tables(catalog)
+
+        # WHEN we list tables
+        tables = catalog.list_tables(NAMESPACE)
+
+        # THEN all four tables exist
+        table_names = {t[1] for t in tables}
+        assert "raw_orderbook" in table_names
+        assert "raw_trades" in table_names
+        assert "features" in table_names
+        assert "predictions" in table_names
+
+    def test_create_tables_is_idempotent(self, catalog):
+        """create_tables can be called multiple times without error."""
+        # GIVEN a catalog
+        # WHEN we create tables twice
+        create_tables(catalog)
+        create_tables(catalog)
+
+        # THEN no exception is raised and tables still exist
+        tables = catalog.list_tables(NAMESPACE)
+        assert len(tables) == 4
+
+
+class TestRawOrderbookSchema:
+    """Tests for raw_orderbook table schema."""
+
+    def test_raw_orderbook_has_timestamp_ms(self, catalog):
+        """raw_orderbook has timestamp_ms bigint column."""
+        # GIVEN tables are created
+        create_tables(catalog)
+
+        # WHEN we load the table
+        table = catalog.load_table(f"{NAMESPACE}.raw_orderbook")
+
+        # THEN timestamp_ms field exists and is required
+        field = table.schema().find_field("timestamp_ms")
+        assert field is not None
+        assert field.required is True
+        assert str(field.field_type) == "long"
+
+    def test_raw_orderbook_has_symbol(self, catalog):
+        """raw_orderbook has symbol string column."""
+        # GIVEN tables are created
+        create_tables(catalog)
+
+        # WHEN we load the table
+        table = catalog.load_table(f"{NAMESPACE}.raw_orderbook")
+
+        # THEN symbol field exists
+        field = table.schema().find_field("symbol")
+        assert field is not None
+        assert str(field.field_type) == "string"
+
+    def test_raw_orderbook_has_10_bid_levels(self, catalog):
+        """raw_orderbook has bid_0 through bid_9 price and size columns."""
+        # GIVEN tables are created
+        create_tables(catalog)
+
+        # WHEN we load the table
+        table = catalog.load_table(f"{NAMESPACE}.raw_orderbook")
+
+        # THEN all 10 bid levels exist with decimal(18,8) type
+        for i in range(ORDER_BOOK_DEPTH):
+            price_field = table.schema().find_field(f"bid_{i}_price")
+            size_field = table.schema().find_field(f"bid_{i}_size")
+            assert price_field is not None, f"bid_{i}_price not found"
+            assert size_field is not None, f"bid_{i}_size not found"
+            assert "decimal(18, 8)" in str(price_field.field_type)
+            assert "decimal(18, 8)" in str(size_field.field_type)
+
+    def test_raw_orderbook_has_10_ask_levels(self, catalog):
+        """raw_orderbook has ask_0 through ask_9 price and size columns."""
+        # GIVEN tables are created
+        create_tables(catalog)
+
+        # WHEN we load the table
+        table = catalog.load_table(f"{NAMESPACE}.raw_orderbook")
+
+        # THEN all 10 ask levels exist with decimal(18,8) type
+        for i in range(ORDER_BOOK_DEPTH):
+            price_field = table.schema().find_field(f"ask_{i}_price")
+            size_field = table.schema().find_field(f"ask_{i}_size")
+            assert price_field is not None, f"ask_{i}_price not found"
+            assert size_field is not None, f"ask_{i}_size not found"
+            assert "decimal(18, 8)" in str(price_field.field_type)
+            assert "decimal(18, 8)" in str(size_field.field_type)
+
+    def test_raw_orderbook_has_received_at(self, catalog):
+        """raw_orderbook has received_at timestamp column."""
+        # GIVEN tables are created
+        create_tables(catalog)
+
+        # WHEN we load the table
+        table = catalog.load_table(f"{NAMESPACE}.raw_orderbook")
+
+        # THEN received_at field exists
+        field = table.schema().find_field("received_at")
+        assert field is not None
+        assert "timestamp" in str(field.field_type).lower()
+
+
+class TestRawTradesSchema:
+    """Tests for raw_trades table schema."""
+
+    def test_raw_trades_has_trade_id(self, catalog):
+        """raw_trades has trade_id string column."""
+        # GIVEN tables are created
+        create_tables(catalog)
+
+        # WHEN we load the table
+        table = catalog.load_table(f"{NAMESPACE}.raw_trades")
+
+        # THEN trade_id field exists
+        field = table.schema().find_field("trade_id")
+        assert field is not None
+        assert str(field.field_type) == "string"
+
+    def test_raw_trades_has_price_decimal(self, catalog):
+        """raw_trades has price decimal(18,8) column."""
+        # GIVEN tables are created
+        create_tables(catalog)
+
+        # WHEN we load the table
+        table = catalog.load_table(f"{NAMESPACE}.raw_trades")
+
+        # THEN price field is decimal(18,8)
+        field = table.schema().find_field("price")
+        assert field is not None
+        assert "decimal(18, 8)" in str(field.field_type)
+
+    def test_raw_trades_has_size_decimal(self, catalog):
+        """raw_trades has size decimal(18,8) column."""
+        # GIVEN tables are created
+        create_tables(catalog)
+
+        # WHEN we load the table
+        table = catalog.load_table(f"{NAMESPACE}.raw_trades")
+
+        # THEN size field is decimal(18,8)
+        field = table.schema().find_field("size")
+        assert field is not None
+        assert "decimal(18, 8)" in str(field.field_type)
+
+    def test_raw_trades_has_side(self, catalog):
+        """raw_trades has side string column."""
+        # GIVEN tables are created
+        create_tables(catalog)
+
+        # WHEN we load the table
+        table = catalog.load_table(f"{NAMESPACE}.raw_trades")
+
+        # THEN side field exists
+        field = table.schema().find_field("side")
+        assert field is not None
+        assert str(field.field_type) == "string"
+
+
+class TestFeaturesSchema:
+    """Tests for features table schema."""
+
+    def test_features_has_all_feature_columns(self, catalog):
+        """features has spread_bps, imbalance, depth, volatility, trade_imbalance."""
+        # GIVEN tables are created
+        create_tables(catalog)
+
+        # WHEN we load the table
+        table = catalog.load_table(f"{NAMESPACE}.features")
+
+        # THEN all feature columns exist as float
+        for col in [
+            "spread_bps",
+            "imbalance",
+            "depth",
+            "volatility",
+            "trade_imbalance",
+        ]:
+            field = table.schema().find_field(col)
+            assert field is not None, f"{col} not found"
+            assert str(field.field_type) == "float"
+
+
+class TestPredictionsSchema:
+    """Tests for predictions table schema."""
+
+    def test_predictions_has_model_id(self, catalog):
+        """predictions has model_id string column."""
+        # GIVEN tables are created
+        create_tables(catalog)
+
+        # WHEN we load the table
+        table = catalog.load_table(f"{NAMESPACE}.predictions")
+
+        # THEN model_id field exists
+        field = table.schema().find_field("model_id")
+        assert field is not None
+        assert str(field.field_type) == "string"
+
+    def test_predictions_has_prediction_int(self, catalog):
+        """predictions has prediction integer column."""
+        # GIVEN tables are created
+        create_tables(catalog)
+
+        # WHEN we load the table
+        table = catalog.load_table(f"{NAMESPACE}.predictions")
+
+        # THEN prediction field is int
+        field = table.schema().find_field("prediction")
+        assert field is not None
+        assert str(field.field_type) == "int"
+
+    def test_predictions_has_probability_float(self, catalog):
+        """predictions has probability float column."""
+        # GIVEN tables are created
+        create_tables(catalog)
+
+        # WHEN we load the table
+        table = catalog.load_table(f"{NAMESPACE}.predictions")
+
+        # THEN probability field is float
+        field = table.schema().find_field("probability")
+        assert field is not None
+        assert str(field.field_type) == "float"
+
+    def test_predictions_has_label_nullable(self, catalog):
+        """predictions has label as nullable integer."""
+        # GIVEN tables are created
+        create_tables(catalog)
+
+        # WHEN we load the table
+        table = catalog.load_table(f"{NAMESPACE}.predictions")
+
+        # THEN label field is optional
+        field = table.schema().find_field("label")
+        assert field is not None
+        assert field.required is False
+
+    def test_predictions_has_labeled_at_ms(self, catalog):
+        """predictions has labeled_at_ms bigint column."""
+        # GIVEN tables are created
+        create_tables(catalog)
+
+        # WHEN we load the table
+        table = catalog.load_table(f"{NAMESPACE}.predictions")
+
+        # THEN labeled_at_ms field exists
+        field = table.schema().find_field("labeled_at_ms")
+        assert field is not None
+        assert str(field.field_type) == "long"


### PR DESCRIPTION
## Summary

- Add docker-compose.yml with Postgres 16 for local Iceberg catalog
- Add pyiceberg[sql-postgres] and psycopg2-binary dependencies  
- Create src/storage/ package with catalog factory and table schemas
- Define 4 Iceberg tables: raw_orderbook (10 levels), raw_trades, features, and predictions
- Add Postgres service container to GitHub Actions CI
- Add integration tests (21 tests) validating connectivity, table creation, and schema correctness
- Update README with Docker setup instructions

## Test plan

- [x] All 21 storage integration tests pass locally with Docker Postgres
- [x] Full test suite passes (122 tests, 84% coverage)
- [x] Linting passes (black, ruff, mypy)
- [ ] CI pipeline passes with Postgres service container

Closes #41