### PR TITLE
feat: increase order book depth from 3 to 10 levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Order book depth increased from 3 to 10 levels for richer market microstructure data
+
 ### Planned
 - Unit tests for core components
 - ETH-USD support

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,7 +40,7 @@ Internal modules and their responsibilities.
 src/
 ├── ingest/
 │   ├── websocket_client.py   # Coinbase WS connection, reconnection logic
-│   └── order_book.py         # Thread-safe order book cache (top-3 levels)
+│   └── order_book.py         # Thread-safe order book cache (top-10 levels)
 │
 ├── features/
 │   ├── extractor.py          # Computes spread_bps, imbalance, depth, volatility
@@ -68,7 +68,7 @@ Live tick to prediction and dashboard flow.
 
 ```mermaid
 flowchart TD
-    A[1. Coinbase WS sends L2 update] --> B[2. Order Book updates top-3 bids/asks]
+    A[1. Coinbase WS sends L2 update] --> B[2. Order Book updates top-10 bids/asks]
     B --> C[3. Feature Extractor computes:<br/>spread_bps, imbalance, depth, volatility]
     C --> D[4. Classifier predicts P price_change]
     D --> E[5. Labeler buffers timestamp, price, features, prediction]

--- a/docs/design/data-layer.md
+++ b/docs/design/data-layer.md
@@ -22,7 +22,7 @@ flowchart TB
 
     subgraph Ingestion["Ingestion Layer"]
         WSClient[WebSocketClient]
-        OB[OrderBook<br/>depth=3]
+        OB[OrderBook<br/>depth=10]
     end
 
     subgraph Features["Feature Layer"]
@@ -53,7 +53,7 @@ flowchart TB
 
 **Limitations:**
 - Only L2 data, no trades
-- Only top 3 levels kept
+- Only top 10 levels kept
 - All data in-memory, lost on restart
 - No historical replay capability
 

--- a/docs/mldesign.md
+++ b/docs/mldesign.md
@@ -25,7 +25,7 @@ Where:
 |---------|---------|-------------|
 | `spread_bps` | $\frac{p_{\text{ask}} - p_{\text{bid}}}{p_{\text{mid}}} \times 10000$ | Spread in basis points |
 | `imbalance` | $\frac{V_{\text{bid}} - V_{\text{ask}}}{V_{\text{bid}} + V_{\text{ask}}}$ | Order book imbalance at top level $\in [-1, 1]$ |
-| `depth` | $\sum_{i=1}^{3} V_{\text{bid},i} + \sum_{i=1}^{3} V_{\text{ask},i}$ | Total volume at top-3 levels |
+| `depth` | $\sum_{i=1}^{10} V_{\text{bid},i} + \sum_{i=1}^{10} V_{\text{ask},i}$ | Total volume at top-10 levels |
 | `volatility` | $\sigma\left(\frac{\Delta p_{\text{mid}}}{p_{\text{mid}}}\right)$ | Rolling std of mid-price changes (bps) |
 
 ### Future Features (Not Yet Implemented)

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -42,7 +42,7 @@ Basically: **streaming data -> features -> predictions -> trading decisions -> d
 
 ## Current Status
 
-- Coinbase WebSocket for L2 order book (only keeping top 3 levels)
+- Coinbase WebSocket for L2 order book (keeping top 10 levels)
 - 4 basic features: spread_bps, imbalance, depth, volatility
 - SGDClassifier that trains online
 - Dash dashboard that polls every 300ms

--- a/src/ingest/order_book.py
+++ b/src/ingest/order_book.py
@@ -1,4 +1,4 @@
-"""Order book cache maintaining top-N bid/ask levels."""
+"""Order book cache maintaining top-10 bid/ask levels."""
 
 import threading
 from dataclasses import dataclass
@@ -24,7 +24,7 @@ class OrderBook:
     Processes Coinbase L2 snapshot and update messages.
     """
 
-    def __init__(self, depth: int = 3):
+    def __init__(self, depth: int = 10):
         """Initialize order book.
 
         Args:

--- a/src/run_live.py
+++ b/src/run_live.py
@@ -45,7 +45,7 @@ class QuoteWatchRunner:
             symbol: Trading pair to track.
         """
         self.symbol = symbol
-        self.order_book = OrderBook(depth=3)
+        self.order_book = OrderBook(depth=10)
         self.feature_extractor = FeatureExtractor(volatility_window=50)
         self.stability_scorer = StabilityScorer()  # Keep as fallback
 


### PR DESCRIPTION
## Summary
- Change `OrderBook` default depth from 3 to 10 levels to capture richer market microstructure data
- Update `QuoteWatchRunner` to use the new depth
- Update all documentation references from "top-3" to "top-10"

## Test plan
- [x] All existing tests pass (103 passed, 19 skipped)
- [x] Linting passes (black, ruff, mypy)
- [x] `FeatureExtractor._compute_depth()` already sums all levels in the snapshot, so it automatically computes depth over 10 levels now

Closes #44