### PR TITLE
feat: add TradeBuffer and matches channel support

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,7 +40,8 @@ Internal modules and their responsibilities.
 src/
 ├── ingest/
 │   ├── websocket_client.py   # Coinbase WS connection, reconnection logic
-│   └── order_book.py         # Thread-safe order book cache (top-10 levels)
+│   ├── order_book.py         # Thread-safe order book cache (top-10 levels)
+│   └── trade_buffer.py       # Thread-safe buffer for recent trades (matches channel)
 │
 ├── features/
 │   ├── extractor.py          # Computes spread_bps, imbalance, depth, volatility

--- a/docs/design/data-layer.md
+++ b/docs/design/data-layer.md
@@ -543,3 +543,42 @@ Configuration is driven by environment variables (`ICEBERG_CATALOG_URI`, `ICEBER
    - Catalog connectivity
    - Table creation and idempotency
    - Schema validation for all 4 tables
+
+### Step 4: Increase Order Book Depth to 10 (Issue #44)
+
+**Status:** Complete (PR #45)
+
+**What was implemented:**
+
+1. Changed default depth from 3 to 10 in `OrderBook.__init__()`
+2. Updated `QuoteWatchRunner` to use `depth=10`
+3. Updated all documentation referencing "top-3" to "top-10"
+
+### Step 5: Add Matches Channel + TradeBuffer (Issue #46)
+
+**Status:** Complete (PR #55)
+
+**What was implemented:**
+
+1. **Trade dataclass** (`src/ingest/trade_buffer.py`)
+   - `trade_id`, `timestamp_ms`, `price`, `size`, `side`
+   - Decimal precision for price/size
+
+2. **TradeBuffer class** (`src/ingest/trade_buffer.py`)
+   - Thread-safe deque with configurable `max_trades` (default 1000)
+   - `add_trade()`, `get_recent()`, `get_trades_since()`, `clear()`
+   - RLock for thread safety
+
+3. **WebSocket client changes** (`src/ingest/websocket_client.py`)
+   - Optional `trade_buffer` parameter
+   - Optional `on_trade` callback
+   - Subscribes to `matches` channel when trade_buffer is provided
+   - Handles `match` message type
+   - ISO8601 timestamp parsing to epoch milliseconds
+
+4. **Exports** (`src/ingest/__init__.py`)
+   - `Trade` and `TradeBuffer` now exported
+
+5. **Tests**
+   - 15 tests for TradeBuffer (add, get_recent, get_trades_since, max_trades, thread safety)
+   - 6 tests for WebSocket match handling

--- a/src/ingest/__init__.py
+++ b/src/ingest/__init__.py
@@ -1,6 +1,7 @@
-"""Ingestion module: WebSocket client and order book cache."""
+"""Ingestion module: WebSocket client, order book cache, and trade buffer."""
 
 from .order_book import OrderBook
+from .trade_buffer import Trade, TradeBuffer
 from .websocket_client import CoinbaseWebSocketClient
 
-__all__ = ["OrderBook", "CoinbaseWebSocketClient"]
+__all__ = ["OrderBook", "Trade", "TradeBuffer", "CoinbaseWebSocketClient"]

--- a/src/ingest/trade_buffer.py
+++ b/src/ingest/trade_buffer.py
@@ -1,0 +1,87 @@
+"""Trade buffer for storing recent trades from Coinbase matches channel."""
+
+import threading
+from collections import deque
+from dataclasses import dataclass
+from decimal import Decimal
+
+
+@dataclass
+class Trade:
+    """A single trade execution from the matches channel.
+
+    Attributes:
+        trade_id: Unique identifier for the trade.
+        timestamp_ms: Trade execution time in milliseconds since epoch.
+        price: Execution price.
+        size: Trade size (quantity).
+        side: Taker side - "buy" (buyer lifted ask) or "sell" (seller hit bid).
+    """
+
+    trade_id: str
+    timestamp_ms: int
+    price: Decimal
+    size: Decimal
+    side: str
+
+
+class TradeBuffer:
+    """Thread-safe buffer for recent trades.
+
+    Stores trades in a fixed-size deque, dropping oldest trades when full.
+    All methods are thread-safe via RLock.
+    """
+
+    def __init__(self, max_trades: int = 1000):
+        """Initialize trade buffer.
+
+        Args:
+            max_trades: Maximum number of trades to store. Oldest dropped when exceeded.
+        """
+        self.max_trades = max_trades
+        self._trades: deque[Trade] = deque(maxlen=max_trades)
+        self._lock = threading.RLock()
+
+    def add_trade(self, trade: Trade) -> None:
+        """Add a trade to the buffer.
+
+        Args:
+            trade: Trade to add. If buffer is full, oldest trade is dropped.
+        """
+        with self._lock:
+            self._trades.append(trade)
+
+    def get_recent(self, n: int = 100) -> list[Trade]:
+        """Get the N most recent trades.
+
+        Args:
+            n: Number of trades to return.
+
+        Returns:
+            List of trades, most recent first.
+        """
+        with self._lock:
+            # deque stores oldest first, so reverse and take first n
+            trades = list(self._trades)
+            trades.reverse()
+            return trades[:n]
+
+    def get_trades_since(self, timestamp_ms: int) -> list[Trade]:
+        """Get all trades since a given timestamp.
+
+        Args:
+            timestamp_ms: Timestamp in milliseconds. Returns trades with
+                timestamp > timestamp_ms (exclusive).
+
+        Returns:
+            List of trades after the timestamp, most recent first.
+        """
+        with self._lock:
+            trades = [t for t in self._trades if t.timestamp_ms > timestamp_ms]
+            trades.reverse()
+            return trades
+
+    def clear(self) -> None:
+        """Clear all trades from the buffer."""
+        with self._lock:
+            self._trades.clear()

--- a/tests/test_trade_buffer.py
+++ b/tests/test_trade_buffer.py
@@ -1,0 +1,284 @@
+"""Unit tests for Trade dataclass and TradeBuffer class."""
+
+import threading
+from decimal import Decimal
+
+from src.ingest.trade_buffer import Trade, TradeBuffer
+
+
+def _make_trade(
+    trade_id: str = "123",
+    timestamp_ms: int = 1000,
+    price: str = "50000.00",
+    size: str = "0.01",
+    side: str = "buy",
+) -> Trade:
+    """Helper to create a Trade with defaults."""
+    return Trade(
+        trade_id=trade_id,
+        timestamp_ms=timestamp_ms,
+        price=Decimal(price),
+        size=Decimal(size),
+        side=side,
+    )
+
+
+class TestTrade:
+    """Tests for Trade dataclass."""
+
+    def test_trade_stores_all_fields(self):
+        """Trade stores trade_id, timestamp_ms, price, size, side."""
+        # GIVEN trade data
+        # WHEN we create a Trade
+        trade = Trade(
+            trade_id="abc123",
+            timestamp_ms=1702656000000,
+            price=Decimal("50000.50"),
+            size=Decimal("0.025"),
+            side="buy",
+        )
+
+        # THEN all fields are stored correctly
+        assert trade.trade_id == "abc123"
+        assert trade.timestamp_ms == 1702656000000
+        assert trade.price == Decimal("50000.50")
+        assert trade.size == Decimal("0.025")
+        assert trade.side == "buy"
+
+    def test_trade_side_can_be_sell(self):
+        """Trade side can be 'sell'."""
+        # GIVEN a sell trade
+        trade = _make_trade(side="sell")
+
+        # THEN side is stored as sell
+        assert trade.side == "sell"
+
+
+class TestTradeBufferAddTrade:
+    """Tests for TradeBuffer.add_trade()."""
+
+    def test_add_trade_stores_trade(self):
+        """add_trade stores a trade in the buffer."""
+        # GIVEN an empty buffer
+        buffer = TradeBuffer()
+
+        # WHEN we add a trade
+        trade = _make_trade()
+        buffer.add_trade(trade)
+
+        # THEN the trade is stored
+        trades = buffer.get_recent(1)
+        assert len(trades) == 1
+        assert trades[0] == trade
+
+    def test_add_trade_maintains_order(self):
+        """add_trade maintains insertion order (oldest first)."""
+        # GIVEN a buffer with trades
+        buffer = TradeBuffer()
+        trade1 = _make_trade(trade_id="1", timestamp_ms=1000)
+        trade2 = _make_trade(trade_id="2", timestamp_ms=2000)
+        trade3 = _make_trade(trade_id="3", timestamp_ms=3000)
+
+        # WHEN we add trades in order
+        buffer.add_trade(trade1)
+        buffer.add_trade(trade2)
+        buffer.add_trade(trade3)
+
+        # THEN get_recent returns most recent first
+        trades = buffer.get_recent(3)
+        assert trades[0] == trade3
+        assert trades[1] == trade2
+        assert trades[2] == trade1
+
+
+class TestTradeBufferMaxTrades:
+    """Tests for TradeBuffer max_trades limit."""
+
+    def test_max_trades_drops_oldest(self):
+        """Buffer drops oldest trades when max_trades exceeded."""
+        # GIVEN a buffer with max_trades=2
+        buffer = TradeBuffer(max_trades=2)
+        trade1 = _make_trade(trade_id="1")
+        trade2 = _make_trade(trade_id="2")
+        trade3 = _make_trade(trade_id="3")
+
+        # WHEN we add 3 trades
+        buffer.add_trade(trade1)
+        buffer.add_trade(trade2)
+        buffer.add_trade(trade3)
+
+        # THEN only the 2 most recent remain
+        trades = buffer.get_recent(10)
+        assert len(trades) == 2
+        assert trades[0].trade_id == "3"
+        assert trades[1].trade_id == "2"
+
+    def test_default_max_trades_is_1000(self):
+        """Default max_trades is 1000."""
+        # GIVEN a buffer with default max_trades
+        buffer = TradeBuffer()
+
+        # THEN max_trades is 1000
+        assert buffer.max_trades == 1000
+
+
+class TestTradeBufferGetRecent:
+    """Tests for TradeBuffer.get_recent()."""
+
+    def test_get_recent_returns_n_trades(self):
+        """get_recent returns the N most recent trades."""
+        # GIVEN a buffer with 5 trades
+        buffer = TradeBuffer()
+        for i in range(5):
+            buffer.add_trade(_make_trade(trade_id=str(i), timestamp_ms=i * 1000))
+
+        # WHEN we get 3 recent trades
+        trades = buffer.get_recent(3)
+
+        # THEN we get the 3 most recent (newest first)
+        assert len(trades) == 3
+        assert trades[0].trade_id == "4"
+        assert trades[1].trade_id == "3"
+        assert trades[2].trade_id == "2"
+
+    def test_get_recent_returns_all_if_n_exceeds_count(self):
+        """get_recent returns all trades if n exceeds buffer size."""
+        # GIVEN a buffer with 2 trades
+        buffer = TradeBuffer()
+        buffer.add_trade(_make_trade(trade_id="1"))
+        buffer.add_trade(_make_trade(trade_id="2"))
+
+        # WHEN we request 10 trades
+        trades = buffer.get_recent(10)
+
+        # THEN we get all 2 trades
+        assert len(trades) == 2
+
+    def test_get_recent_empty_buffer_returns_empty_list(self):
+        """get_recent on empty buffer returns empty list."""
+        # GIVEN an empty buffer
+        buffer = TradeBuffer()
+
+        # WHEN we get recent trades
+        trades = buffer.get_recent(10)
+
+        # THEN we get an empty list
+        assert trades == []
+
+    def test_get_recent_default_is_100(self):
+        """get_recent default n is 100."""
+        # GIVEN a buffer with 150 trades
+        buffer = TradeBuffer()
+        for i in range(150):
+            buffer.add_trade(_make_trade(trade_id=str(i)))
+
+        # WHEN we call get_recent without n
+        trades = buffer.get_recent()
+
+        # THEN we get 100 trades
+        assert len(trades) == 100
+
+
+class TestTradeBufferGetTradesSince:
+    """Tests for TradeBuffer.get_trades_since()."""
+
+    def test_get_trades_since_filters_by_timestamp(self):
+        """get_trades_since returns trades after given timestamp."""
+        # GIVEN a buffer with trades at different timestamps
+        buffer = TradeBuffer()
+        buffer.add_trade(_make_trade(trade_id="1", timestamp_ms=1000))
+        buffer.add_trade(_make_trade(trade_id="2", timestamp_ms=2000))
+        buffer.add_trade(_make_trade(trade_id="3", timestamp_ms=3000))
+        buffer.add_trade(_make_trade(trade_id="4", timestamp_ms=4000))
+
+        # WHEN we get trades since 2000
+        trades = buffer.get_trades_since(2000)
+
+        # THEN we get trades with timestamp > 2000 (newest first)
+        assert len(trades) == 2
+        assert trades[0].trade_id == "4"
+        assert trades[1].trade_id == "3"
+
+    def test_get_trades_since_excludes_exact_timestamp(self):
+        """get_trades_since excludes trades at exactly the given timestamp."""
+        # GIVEN a buffer with a trade at exactly 2000
+        buffer = TradeBuffer()
+        buffer.add_trade(_make_trade(trade_id="1", timestamp_ms=2000))
+        buffer.add_trade(_make_trade(trade_id="2", timestamp_ms=3000))
+
+        # WHEN we get trades since 2000
+        trades = buffer.get_trades_since(2000)
+
+        # THEN the trade at 2000 is excluded
+        assert len(trades) == 1
+        assert trades[0].trade_id == "2"
+
+    def test_get_trades_since_returns_empty_if_none_match(self):
+        """get_trades_since returns empty list if no trades after timestamp."""
+        # GIVEN a buffer with trades before the cutoff
+        buffer = TradeBuffer()
+        buffer.add_trade(_make_trade(timestamp_ms=1000))
+        buffer.add_trade(_make_trade(timestamp_ms=2000))
+
+        # WHEN we get trades since 5000
+        trades = buffer.get_trades_since(5000)
+
+        # THEN we get an empty list
+        assert trades == []
+
+
+class TestTradeBufferClear:
+    """Tests for TradeBuffer.clear()."""
+
+    def test_clear_removes_all_trades(self):
+        """clear removes all trades from buffer."""
+        # GIVEN a buffer with trades
+        buffer = TradeBuffer()
+        buffer.add_trade(_make_trade(trade_id="1"))
+        buffer.add_trade(_make_trade(trade_id="2"))
+
+        # WHEN we clear
+        buffer.clear()
+
+        # THEN buffer is empty
+        assert buffer.get_recent(10) == []
+
+
+class TestTradeBufferThreadSafety:
+    """Tests for TradeBuffer thread safety."""
+
+    def test_concurrent_add_and_read(self):
+        """Buffer handles concurrent adds and reads safely."""
+        # GIVEN a buffer
+        buffer = TradeBuffer(max_trades=1000)
+        errors = []
+
+        def add_trades():
+            try:
+                for i in range(100):
+                    buffer.add_trade(_make_trade(trade_id=str(i), timestamp_ms=i))
+            except Exception as e:
+                errors.append(e)
+
+        def read_trades():
+            try:
+                for _ in range(100):
+                    buffer.get_recent(50)
+                    buffer.get_trades_since(50)
+            except Exception as e:
+                errors.append(e)
+
+        # WHEN we run concurrent adds and reads
+        threads = [
+            threading.Thread(target=add_trades),
+            threading.Thread(target=add_trades),
+            threading.Thread(target=read_trades),
+            threading.Thread(target=read_trades),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # THEN no errors occurred
+        assert errors == []

--- a/tests/test_websocket_client.py
+++ b/tests/test_websocket_client.py
@@ -1,8 +1,10 @@
 """Tests for CoinbaseWebSocketClient."""
 
 import json
+from decimal import Decimal
 
 from src.ingest.order_book import OrderBook
+from src.ingest.trade_buffer import Trade, TradeBuffer
 from src.ingest.websocket_client import CoinbaseWebSocketClient
 
 
@@ -219,3 +221,176 @@ class TestCoinbaseWebSocketClient:
         client.process_message(message)
 
         # THEN no exception is raised (implicit assertion)
+
+
+class TestCoinbaseWebSocketClientMatches:
+    """Tests for CoinbaseWebSocketClient match message handling."""
+
+    # =========================================================================
+    # Test Data Helpers
+    # =========================================================================
+
+    def make_client_with_trade_buffer(
+        self,
+        trade_buffer: TradeBuffer | None = None,
+        on_trade=None,
+    ) -> CoinbaseWebSocketClient:
+        """Create a WebSocket client with a trade buffer."""
+        book = OrderBook(depth=3)
+        buffer = trade_buffer or TradeBuffer()
+        return CoinbaseWebSocketClient(
+            order_book=book,
+            trade_buffer=buffer,
+            symbol="BTC-USD",
+            on_trade=on_trade,
+        )
+
+    def make_match_message(
+        self,
+        trade_id: str = "123456789",
+        time: str = "2024-01-01T12:00:00.000000Z",
+        price: str = "50000.00",
+        size: str = "0.01",
+        side: str = "buy",
+    ) -> str:
+        """Create a Coinbase match message."""
+        return json.dumps(
+            {
+                "type": "match",
+                "trade_id": trade_id,
+                "sequence": 50,
+                "maker_order_id": "abc-123",
+                "taker_order_id": "def-456",
+                "time": time,
+                "product_id": "BTC-USD",
+                "size": size,
+                "price": price,
+                "side": side,
+            }
+        )
+
+    # =========================================================================
+    # Tests - Match Message Processing
+    # =========================================================================
+
+    def test_match_message_adds_trade_to_buffer(self):
+        """Match message adds a trade to the trade buffer."""
+        # GIVEN a client with a trade buffer
+        buffer = TradeBuffer()
+        client = self.make_client_with_trade_buffer(trade_buffer=buffer)
+        message = self.make_match_message(
+            trade_id="999",
+            price="51000.50",
+            size="0.025",
+            side="sell",
+        )
+
+        # WHEN we process a match message
+        client.process_message(message)
+
+        # THEN trade is added to buffer
+        trades = buffer.get_recent(1)
+        assert len(trades) == 1
+        assert trades[0].trade_id == "999"
+        assert trades[0].price == Decimal("51000.50")
+        assert trades[0].size == Decimal("0.025")
+        assert trades[0].side == "sell"
+
+    def test_match_message_parses_timestamp_to_ms(self):
+        """Match message parses ISO timestamp to milliseconds."""
+        # GIVEN a client with a trade buffer
+        buffer = TradeBuffer()
+        client = self.make_client_with_trade_buffer(trade_buffer=buffer)
+        # 2024-01-01T12:00:00.123456Z -> epoch ms
+        message = self.make_match_message(time="2024-01-01T12:00:00.123456Z")
+
+        # WHEN we process a match message
+        client.process_message(message)
+
+        # THEN timestamp is in milliseconds
+        trades = buffer.get_recent(1)
+        assert trades[0].timestamp_ms == 1704110400123
+
+    def test_match_message_triggers_on_trade_callback(self):
+        """Match message triggers on_trade callback with Trade object."""
+        # GIVEN a client with an on_trade callback
+        received_trades: list[Trade] = []
+
+        def on_trade(trade: Trade):
+            received_trades.append(trade)
+
+        client = self.make_client_with_trade_buffer(on_trade=on_trade)
+        message = self.make_match_message(trade_id="callback-test")
+
+        # WHEN we process a match message
+        client.process_message(message)
+
+        # THEN callback receives the Trade object
+        assert len(received_trades) == 1
+        assert received_trades[0].trade_id == "callback-test"
+
+    def test_match_message_without_trade_buffer_is_ignored(self):
+        """Match message is ignored if no trade buffer configured."""
+        # GIVEN a client without a trade buffer
+        book = OrderBook(depth=3)
+        client = CoinbaseWebSocketClient(order_book=book, symbol="BTC-USD")
+        message = self.make_match_message()
+
+        # WHEN we process a match message
+        client.process_message(message)
+
+        # THEN no exception is raised (implicit assertion)
+
+    def test_match_message_does_not_trigger_on_update(self):
+        """Match messages do not trigger the on_update callback."""
+        # GIVEN a client with both callbacks
+        update_count = {"count": 0}
+        trade_count = {"count": 0}
+
+        def on_update():
+            update_count["count"] += 1
+
+        def on_trade(trade: Trade):
+            trade_count["count"] += 1
+
+        book = OrderBook(depth=3)
+        buffer = TradeBuffer()
+        client = CoinbaseWebSocketClient(
+            order_book=book,
+            trade_buffer=buffer,
+            symbol="BTC-USD",
+            on_update=on_update,
+            on_trade=on_trade,
+        )
+        message = self.make_match_message()
+
+        # WHEN we process a match message
+        client.process_message(message)
+
+        # THEN only on_trade is called, not on_update
+        assert update_count["count"] == 0
+        assert trade_count["count"] == 1
+
+    def test_match_message_with_integer_trade_id(self):
+        """Match message handles trade_id as integer (Coinbase sends both)."""
+        # GIVEN a message with integer trade_id
+        buffer = TradeBuffer()
+        client = self.make_client_with_trade_buffer(trade_buffer=buffer)
+        message = json.dumps(
+            {
+                "type": "match",
+                "trade_id": 123456789,  # Integer, not string
+                "time": "2024-01-01T12:00:00.000000Z",
+                "product_id": "BTC-USD",
+                "size": "0.01",
+                "price": "50000.00",
+                "side": "buy",
+            }
+        )
+
+        # WHEN we process the message
+        client.process_message(message)
+
+        # THEN trade_id is stored as string
+        trades = buffer.get_recent(1)
+        assert trades[0].trade_id == "123456789"


### PR DESCRIPTION
## Summary
- Add `Trade` dataclass and `TradeBuffer` class for storing recent trades from Coinbase matches channel
- WebSocket client now optionally subscribes to `matches` channel when `trade_buffer` is provided
- Handle `match` messages, parse to `Trade` objects, and invoke `on_trade` callback
- Thread-safe buffer with configurable `max_trades` limit (default 1000)

## Changes
| File | Description |
|------|-------------|
| `src/ingest/trade_buffer.py` | New Trade dataclass + TradeBuffer class |
| `src/ingest/websocket_client.py` | Add trade_buffer param, matches subscription, match handling |
| `src/ingest/__init__.py` | Export Trade, TradeBuffer |
| `tests/test_trade_buffer.py` | 15 unit tests for TradeBuffer |
| `tests/test_websocket_client.py` | 6 tests for match message handling |
| `docs/architecture.md` | Add trade_buffer.py to component diagram |

## Test plan
- [x] All 143 tests pass
- [x] Coverage >= 75%
- [x] Pre-commit hooks pass (black, ruff, mypy)

Closes #46