### PR TITLE
feat: implement DataWriter for features and predictions tables

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,6 +52,7 @@ src/
 │   └── classifier.py         # OnlineClassifier: SGDClassifier + StandardScaler
 │                              # - partial_fit() for online learning
 │                              # - record_prediction() for accuracy tracking
+│                              # - Prediction dataclass for labeled predictions
 │
 ├── storage/
 │   ├── catalog.py            # Iceberg catalog factory (Postgres-backed)

--- a/src/features/extractor.py
+++ b/src/features/extractor.py
@@ -17,6 +17,7 @@ class FeatureSnapshot:
     depth: float  # Total volume at top levels (in base currency)
     volatility: float  # Rolling std of mid-price changes (in bps)
     timestamp: str | None = None
+    timestamp_ms: int | None = None  # Exchange timestamp (ms since epoch)
 
 
 class FeatureExtractor:
@@ -69,6 +70,7 @@ class FeatureExtractor:
                 depth=depth,
                 volatility=volatility,
                 timestamp=snapshot.timestamp,
+                timestamp_ms=snapshot.timestamp_ms,
             )
 
     def _compute_spread_bps(self, snapshot: OrderBookSnapshot) -> float:

--- a/src/model/__init__.py
+++ b/src/model/__init__.py
@@ -1,5 +1,5 @@
 """ML model components for price change prediction."""
 
-from src.model.classifier import OnlineClassifier
+from src.model.classifier import OnlineClassifier, Prediction
 
-__all__ = ["OnlineClassifier"]
+__all__ = ["OnlineClassifier", "Prediction"]

--- a/src/model/classifier.py
+++ b/src/model/classifier.py
@@ -12,6 +12,20 @@ from src.features.extractor import FeatureSnapshot
 
 
 @dataclass
+class Prediction:
+    """A model prediction with its eventual label.
+
+    Created when a prediction is made and labeled after the prediction horizon.
+    """
+
+    timestamp_ms: int  # When prediction was made (ms since epoch)
+    prediction: int  # Predicted class (0 or 1)
+    probability: float  # P(price_change) in [0, 1]
+    label: int  # Actual outcome (0 or 1)
+    labeled_at_ms: int  # When label was determined (ms since epoch)
+
+
+@dataclass
 class ModelStats:
     """Statistics about the model's training state."""
 

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,7 +1,7 @@
-"""Tests for OnlineClassifier."""
+"""Tests for OnlineClassifier and Prediction dataclass."""
 
 from src.features.extractor import FeatureSnapshot
-from src.model.classifier import OnlineClassifier
+from src.model.classifier import OnlineClassifier, Prediction
 
 
 class TestOnlineClassifier:
@@ -217,3 +217,44 @@ class TestOnlineClassifier:
 
         # THEN ready_pct is 50%
         assert stats.ready_pct == 50.0
+
+
+class TestPrediction:
+    """Tests for Prediction dataclass."""
+
+    def test_prediction_has_required_fields(self):
+        """Prediction dataclass has all required fields."""
+        # GIVEN prediction data
+        # WHEN we create a Prediction
+        pred = Prediction(
+            timestamp_ms=1704067200000,
+            prediction=1,
+            probability=0.75,
+            label=1,
+            labeled_at_ms=1704067200500,
+        )
+
+        # THEN all fields are accessible
+        assert pred.timestamp_ms == 1704067200000
+        assert pred.prediction == 1
+        assert pred.probability == 0.75
+        assert pred.label == 1
+        assert pred.labeled_at_ms == 1704067200500
+
+    def test_prediction_is_dataclass(self):
+        """Prediction is a proper dataclass."""
+        # GIVEN a Prediction
+        pred = Prediction(
+            timestamp_ms=1704067200000,
+            prediction=0,
+            probability=0.3,
+            label=0,
+            labeled_at_ms=1704067200500,
+        )
+
+        # WHEN we check it's a dataclass (no action)
+
+        # THEN it's an instance of the dataclass
+        from dataclasses import is_dataclass
+
+        assert is_dataclass(pred)

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -204,3 +204,25 @@ class TestFeatureExtractor:
         # THEN timestamp is preserved
         assert result is not None
         assert result.timestamp == "2024-01-01T00:00:00Z"
+
+    def test_timestamp_ms_preserved_in_result(self):
+        """timestamp_ms is passed through to FeatureSnapshot."""
+        # GIVEN an extractor and a snapshot with timestamp_ms
+        extractor = FeatureExtractor()
+        snapshot = OrderBookSnapshot(
+            bids=[(Decimal("100.00"), Decimal("1.0"))],
+            asks=[(Decimal("101.00"), Decimal("1.0"))],
+            best_bid=Decimal("100.00"),
+            best_ask=Decimal("101.00"),
+            mid_price=Decimal("100.50"),
+            spread=Decimal("1.00"),
+            timestamp="2024-01-01T00:00:00Z",
+            timestamp_ms=1704067200000,
+        )
+
+        # WHEN we compute features
+        result = extractor.compute(snapshot)
+
+        # THEN timestamp_ms is preserved
+        assert result is not None
+        assert result.timestamp_ms == 1704067200000


### PR DESCRIPTION
## Summary

- Add `write_features()` and `write_prediction()` methods to DataWriter
- Add `timestamp_ms` field to `FeatureSnapshot` dataclass
- Add new `Prediction` dataclass with labeled prediction data
- Add `model_id` constructor parameter to DataWriter (default "sgd-v1")

## Design Decisions

- **model_id in constructor**: Same pattern as `symbol` - set once per writer instance
- **Write predictions with labels**: Single write after labeling (not separate prediction/update)
- **trade_imbalance**: Writes `None` for now (will be populated when trade flow features are added in #56)

## Test plan

- [x] Unit tests for `write_features()` (4 tests)
- [x] Unit tests for `write_prediction()` (4 tests)
- [x] Unit tests for DataWriter init with model_id (3 tests)
- [x] Integration tests for features and predictions tables (2 tests, skipped without Postgres)
- [x] All existing tests pass
- [x] Linting passes (black, ruff, mypy)

Closes #48