### PR TITLE
feat: wire DataWriter into runner with optional persistence

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -42,9 +42,10 @@ Basically: **streaming data -> features -> predictions -> trading decisions -> d
 
 ## Current Status
 
-- Coinbase WebSocket for L2 order book (keeping top 10 levels)
+- Coinbase WebSocket for L2 order book (keeping top 10 levels) + trades (matches channel)
 - 4 basic features: spread_bps, imbalance, depth, volatility
 - SGDClassifier that trains online
+- Optional persistence to Iceberg/Parquet (raw data, features, predictions)
 - Dash dashboard that polls every 300ms
 - Running on Google Cloud Run
 - Simple rolling accuracy tracking
@@ -60,7 +61,7 @@ Basically: **streaming data -> features -> predictions -> trading decisions -> d
 |------|-----|------|--------|
 | More depth (10-20 levels, not 3) | Better features, more signal | [#35](https://github.com/elinsky/market-microstructure-ml/issues/35) | done |
 | Trade data (matches channel) | Trade flow imbalance, aggressor detection | [#35](https://github.com/elinsky/market-microstructure-ml/issues/35) | done |
-| Save data to disk (Parquet or DB) | Backtesting, retraining | [#35](https://github.com/elinsky/market-microstructure-ml/issues/35) | in progress |
+| Save data to disk (Parquet or DB) | Backtesting, retraining | [#35](https://github.com/elinsky/market-microstructure-ml/issues/35) | done |
 | Replay historical data | Test models on past data | [#35](https://github.com/elinsky/market-microstructure-ml/issues/35) | - |
 | Multi-symbol (BTC + ETH) | Shows it's not hardcoded | - | - |
 

--- a/tests/test_labeler.py
+++ b/tests/test_labeler.py
@@ -147,6 +147,34 @@ class TestLabeler:
         assert result is not None
         assert result.prediction_at_t == 1
 
+    def test_probability_stored_with_sample(self):
+        """Probability at time t is stored in labeled sample."""
+        # GIVEN a labeler with a sample that includes a probability
+        labeler = self.make_labeler(delta_ms=500)
+        features = self.make_features()
+        labeler.add_sample(1000, 100.0, features, prediction=1, probability=0.75)
+
+        # WHEN the label is emitted
+        result = labeler.add_sample(1500, 100.0, features)
+
+        # THEN the probability is included in the result
+        assert result is not None
+        assert result.probability_at_t == 0.75
+
+    def test_probability_defaults_to_none(self):
+        """Probability defaults to None when not provided."""
+        # GIVEN a labeler with a sample without probability
+        labeler = self.make_labeler(delta_ms=500)
+        features = self.make_features()
+        labeler.add_sample(1000, 100.0, features, prediction=1)
+
+        # WHEN the label is emitted
+        result = labeler.add_sample(1500, 100.0, features)
+
+        # THEN the probability is None
+        assert result is not None
+        assert result.probability_at_t is None
+
     def test_flush_clears_buffer(self):
         """Flush clears all buffered samples."""
         # GIVEN a labeler with samples in the buffer

--- a/tests/test_run_live.py
+++ b/tests/test_run_live.py
@@ -1,8 +1,11 @@
 """Tests for QuoteWatchRunner."""
 
+import os
 from decimal import Decimal
+from unittest.mock import MagicMock, patch
 
 from src.ingest.order_book import OrderBookSnapshot
+from src.ingest.trade_buffer import Trade
 from src.run_live import PipelineResult, QuoteWatchRunner
 
 
@@ -27,6 +30,8 @@ class TestQuoteWatchRunner:
         runner.stability_scorer = StabilityScorer()
         runner.labeler = Labeler(delta_ms=500, threshold_pct=0.01)
         runner.classifier = OnlineClassifier(learning_rate=0.01)
+        runner._writer = None
+        runner._trade_buffer = None
         return runner
 
     def make_empty_snapshot(self) -> OrderBookSnapshot:
@@ -191,3 +196,288 @@ class TestQuoteWatchRunner:
 
         # THEN classifier has received training samples
         assert runner.classifier.sample_count >= 1
+
+
+class TestQuoteWatchRunnerPersistence:
+    """Tests for QuoteWatchRunner persistence functionality."""
+
+    # =========================================================================
+    # Test Data Helpers
+    # =========================================================================
+
+    def make_snapshot(
+        self,
+        best_bid: str = "100.00",
+        best_ask: str = "101.00",
+        timestamp: str | None = "2024-01-01T00:00:00Z",
+    ) -> OrderBookSnapshot:
+        """Create a populated order book snapshot."""
+        bid = Decimal(best_bid)
+        ask = Decimal(best_ask)
+        return OrderBookSnapshot(
+            bids=[(bid, Decimal("1.0"))],
+            asks=[(ask, Decimal("1.0"))],
+            best_bid=bid,
+            best_ask=ask,
+            mid_price=(bid + ask) / 2,
+            spread=ask - bid,
+            timestamp=timestamp,
+        )
+
+    def make_trade(self) -> Trade:
+        """Create a test trade."""
+        return Trade(
+            trade_id="123",
+            timestamp_ms=1704067200000,
+            price=Decimal("100.50"),
+            size=Decimal("0.5"),
+            side="buy",
+        )
+
+    # =========================================================================
+    # Tests - Persistence Disabled (default)
+    # =========================================================================
+
+    def test_runner_has_no_writer_when_persistence_disabled(self):
+        """Runner has no DataWriter when ENABLE_PERSISTENCE is not set."""
+        # GIVEN ENABLE_PERSISTENCE is not set
+        env = os.environ.copy()
+        env.pop("ENABLE_PERSISTENCE", None)
+
+        with patch.dict(os.environ, env, clear=True):
+            # WHEN we create a runner
+            runner = QuoteWatchRunner.__new__(QuoteWatchRunner)
+            runner._init_components("BTC-USD")
+
+            # THEN writer is None
+            assert runner._writer is None
+
+    def test_runner_has_no_trade_buffer_when_persistence_disabled(self):
+        """Runner has no TradeBuffer when ENABLE_PERSISTENCE is not set."""
+        # GIVEN ENABLE_PERSISTENCE is not set
+        env = os.environ.copy()
+        env.pop("ENABLE_PERSISTENCE", None)
+
+        with patch.dict(os.environ, env, clear=True):
+            # WHEN we create a runner
+            runner = QuoteWatchRunner.__new__(QuoteWatchRunner)
+            runner._init_components("BTC-USD")
+
+            # THEN trade_buffer is None
+            assert runner._trade_buffer is None
+
+    # =========================================================================
+    # Tests - Persistence Enabled
+    # =========================================================================
+
+    def test_runner_has_trade_buffer_when_persistence_enabled(self):
+        """Runner has TradeBuffer when ENABLE_PERSISTENCE=true."""
+        # GIVEN ENABLE_PERSISTENCE=true and catalog env vars set
+        env = {
+            "ENABLE_PERSISTENCE": "true",
+            "ICEBERG_CATALOG_URI": "postgresql+psycopg2://localhost/test",
+            "ICEBERG_WAREHOUSE": "file:///tmp/warehouse",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            with patch("src.run_live.get_catalog") as mock_get_catalog:
+                with patch("src.run_live.create_tables"):
+                    with patch("src.run_live.DataWriter"):
+                        mock_get_catalog.return_value = MagicMock()
+
+                        # WHEN we create a runner
+                        runner = QuoteWatchRunner.__new__(QuoteWatchRunner)
+                        runner._init_components("BTC-USD")
+
+                        # THEN trade_buffer is initialized
+                        assert runner._trade_buffer is not None
+
+    def test_runner_creates_tables_on_init_when_persistence_enabled(self):
+        """Runner calls create_tables when ENABLE_PERSISTENCE=true."""
+        # GIVEN ENABLE_PERSISTENCE=true
+        env = {
+            "ENABLE_PERSISTENCE": "true",
+            "ICEBERG_CATALOG_URI": "postgresql+psycopg2://localhost/test",
+            "ICEBERG_WAREHOUSE": "file:///tmp/warehouse",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            with patch("src.run_live.get_catalog") as mock_get_catalog:
+                with patch("src.run_live.create_tables") as mock_create_tables:
+                    with patch("src.run_live.DataWriter"):
+                        mock_catalog = MagicMock()
+                        mock_get_catalog.return_value = mock_catalog
+
+                        # WHEN we create a runner
+                        runner = QuoteWatchRunner.__new__(QuoteWatchRunner)
+                        runner._init_components("BTC-USD")
+
+                        # THEN create_tables was called
+                        mock_create_tables.assert_called_once_with(mock_catalog)
+
+    def test_runner_has_writer_when_persistence_enabled(self):
+        """Runner has DataWriter when ENABLE_PERSISTENCE=true."""
+        # GIVEN ENABLE_PERSISTENCE=true
+        env = {
+            "ENABLE_PERSISTENCE": "true",
+            "ICEBERG_CATALOG_URI": "postgresql+psycopg2://localhost/test",
+            "ICEBERG_WAREHOUSE": "file:///tmp/warehouse",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            with patch("src.run_live.get_catalog") as mock_get_catalog:
+                with patch("src.run_live.create_tables"):
+                    with patch("src.run_live.DataWriter") as mock_writer_class:
+                        mock_catalog = MagicMock()
+                        mock_get_catalog.return_value = mock_catalog
+                        mock_writer = MagicMock()
+                        mock_writer_class.return_value = mock_writer
+
+                        # WHEN we create a runner
+                        runner = QuoteWatchRunner.__new__(QuoteWatchRunner)
+                        runner._init_components("BTC-USD")
+
+                        # THEN writer is initialized
+                        assert runner._writer is mock_writer
+                        mock_writer_class.assert_called_once_with(
+                            catalog=mock_catalog, symbol="BTC-USD"
+                        )
+
+    # =========================================================================
+    # Tests - Write Operations
+    # =========================================================================
+
+    def test_process_snapshot_writes_orderbook_when_persistence_enabled(self):
+        """process_snapshot calls write_orderbook when persistence is enabled."""
+        # GIVEN a runner with a mock writer
+        runner = QuoteWatchRunner.__new__(QuoteWatchRunner)
+        from src.features import FeatureExtractor, Labeler, StabilityScorer
+        from src.ingest import OrderBook
+        from src.model import OnlineClassifier
+
+        runner.symbol = "BTC-USD"
+        runner.order_book = OrderBook(depth=3)
+        runner.feature_extractor = FeatureExtractor(volatility_window=50)
+        runner.stability_scorer = StabilityScorer()
+        runner.labeler = Labeler(delta_ms=500, threshold_pct=0.01)
+        runner.classifier = OnlineClassifier(learning_rate=0.01)
+        runner._writer = MagicMock()
+        runner._trade_buffer = None
+
+        snapshot = self.make_snapshot()
+
+        # WHEN we process the snapshot
+        runner.process_snapshot(snapshot, timestamp_ms=1000.0)
+
+        # THEN write_orderbook was called
+        runner._writer.write_orderbook.assert_called_once_with(snapshot)
+
+    def test_process_snapshot_writes_features_when_persistence_enabled(self):
+        """process_snapshot calls write_features when persistence is enabled."""
+        # GIVEN a runner with a mock writer
+        runner = QuoteWatchRunner.__new__(QuoteWatchRunner)
+        from src.features import FeatureExtractor, Labeler, StabilityScorer
+        from src.ingest import OrderBook
+        from src.model import OnlineClassifier
+
+        runner.symbol = "BTC-USD"
+        runner.order_book = OrderBook(depth=3)
+        runner.feature_extractor = FeatureExtractor(volatility_window=50)
+        runner.stability_scorer = StabilityScorer()
+        runner.labeler = Labeler(delta_ms=500, threshold_pct=0.01)
+        runner.classifier = OnlineClassifier(learning_rate=0.01)
+        runner._writer = MagicMock()
+        runner._trade_buffer = None
+
+        snapshot = self.make_snapshot()
+
+        # WHEN we process the snapshot
+        runner.process_snapshot(snapshot, timestamp_ms=1000.0)
+
+        # THEN write_features was called
+        runner._writer.write_features.assert_called_once()
+        written_features = runner._writer.write_features.call_args[0][0]
+        assert written_features.spread_bps > 0
+
+    def test_process_snapshot_does_not_write_when_persistence_disabled(self):
+        """process_snapshot does not write when persistence is disabled."""
+        # GIVEN a runner without a writer
+        runner = QuoteWatchRunner.__new__(QuoteWatchRunner)
+        from src.features import FeatureExtractor, Labeler, StabilityScorer
+        from src.ingest import OrderBook
+        from src.model import OnlineClassifier
+
+        runner.symbol = "BTC-USD"
+        runner.order_book = OrderBook(depth=3)
+        runner.feature_extractor = FeatureExtractor(volatility_window=50)
+        runner.stability_scorer = StabilityScorer()
+        runner.labeler = Labeler(delta_ms=500, threshold_pct=0.01)
+        runner.classifier = OnlineClassifier(learning_rate=0.01)
+        runner._writer = None
+        runner._trade_buffer = None
+
+        snapshot = self.make_snapshot()
+
+        # WHEN we process the snapshot (should not raise)
+        result = runner.process_snapshot(snapshot, timestamp_ms=1000.0)
+
+        # THEN result is still valid
+        assert result.features is not None
+
+    def test_on_trade_writes_trade_when_persistence_enabled(self):
+        """_on_trade callback writes trade to DataWriter."""
+        # GIVEN a runner with a mock writer
+        runner = QuoteWatchRunner.__new__(QuoteWatchRunner)
+        runner._writer = MagicMock()
+
+        trade = self.make_trade()
+
+        # WHEN _on_trade is called
+        runner._on_trade(trade)
+
+        # THEN write_trade was called
+        runner._writer.write_trade.assert_called_once_with(trade)
+
+    def test_on_trade_does_nothing_when_persistence_disabled(self):
+        """_on_trade does nothing when persistence is disabled."""
+        # GIVEN a runner without a writer
+        runner = QuoteWatchRunner.__new__(QuoteWatchRunner)
+        runner._writer = None
+
+        trade = self.make_trade()
+
+        # WHEN _on_trade is called (should not raise)
+        runner._on_trade(trade)
+
+        # THEN no exception is raised (implicit pass)
+
+    # =========================================================================
+    # Tests - Graceful Shutdown
+    # =========================================================================
+
+    def test_stop_flushes_writer_when_persistence_enabled(self):
+        """stop() calls writer.close() for graceful shutdown."""
+        # GIVEN a runner with a mock writer
+        runner = QuoteWatchRunner.__new__(QuoteWatchRunner)
+        runner._writer = MagicMock()
+        runner._loop = None
+        runner.ws_client = MagicMock()
+
+        # WHEN we call stop
+        runner.stop()
+
+        # THEN writer.close() was called
+        runner._writer.close.assert_called_once()
+
+    def test_stop_works_when_persistence_disabled(self):
+        """stop() works without error when persistence is disabled."""
+        # GIVEN a runner without a writer
+        runner = QuoteWatchRunner.__new__(QuoteWatchRunner)
+        runner._writer = None
+        runner._loop = None
+        runner.ws_client = MagicMock()
+
+        # WHEN we call stop (should not raise)
+        runner.stop()
+
+        # THEN no exception is raised (implicit pass)


### PR DESCRIPTION
## Summary

- Wire the `DataWriter` into `QuoteWatchRunner` so live market data is persisted to Iceberg tables
- Add `ENABLE_PERSISTENCE` env var to toggle persistence on/off
- Add `probability_at_t` to `LabeledSample` for complete prediction records

## Changes

### Code
- **LabeledSample** (`src/features/labeler.py`): Added `probability_at_t: float | None` field
- **Labeler.add_sample()**: Now accepts `probability` parameter
- **QuoteWatchRunner** (`src/run_live.py`):
  - `_init_persistence()`: initializes catalog, creates tables, creates DataWriter and TradeBuffer
  - `_on_trade()`: callback writes trades to DataWriter
  - `process_snapshot()`: writes orderbook, features, and predictions (with labels) to DataWriter
  - `stop()`: calls `writer.close()` for graceful shutdown

### Tests
- 12 new persistence tests in `tests/test_run_live.py`
- 2 new labeler tests for `probability_at_t`

### Documentation
- Updated `docs/architecture.md` with persistence in system context diagram
- Updated `docs/prd.md` to mark "Save data to disk" as done
- Updated `docs/design/data-layer.md` with Step 8 implementation progress

## Test plan

- [x] All 172 tests pass
- [x] Linting (black, ruff, mypy) passes
- [ ] Local validation with Postgres:
  ```bash
  docker-compose up -d
  export ENABLE_PERSISTENCE=true
  export ICEBERG_CATALOG_URI="postgresql+psycopg2://postgres:localdev@localhost:5432/iceberg"
  export ICEBERG_WAREHOUSE="file://$(pwd)/data/warehouse"
  python -m src.run_live
  # Verify data in tables after running for a minute
  ```

Closes #49