### PR TITLE
feat: add GCS backend for production persistence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,21 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: Deploy Cloud Function (snapshot expiration)
+        run: |
+          gcloud functions deploy expire-snapshots \
+            --gen2 \
+            --runtime=python311 \
+            --region=us-central1 \
+            --source=functions/expire_snapshots \
+            --entry-point=expire_snapshots \
+            --trigger-http \
+            --no-allow-unauthenticated \
+            --memory=256MB \
+            --timeout=300s \
+            --set-env-vars=ICEBERG_WAREHOUSE=gs://quotewatch-data/warehouse \
+            --set-secrets=ICEBERG_CATALOG_URI=iceberg-catalog-uri:latest
+
       - name: Deploy to Cloud Run
         run: |
           gcloud run deploy quotewatch \
@@ -106,4 +121,8 @@ jobs:
             --min-instances 1 \
             --max-instances 1 \
             --timeout 3600 \
-            --concurrency 80
+            --concurrency 80 \
+            --add-cloudsql-instances quotewatch-prod:us-central1:quotewatch-iceberg \
+            --set-env-vars ENABLE_PERSISTENCE=true \
+            --set-env-vars ICEBERG_WAREHOUSE=gs://quotewatch-data/warehouse \
+            --set-secrets ICEBERG_CATALOG_URI=iceberg-catalog-uri:latest

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,11 @@ data/
 models/
 *.parquet
 .env
+
+# Terraform
+*.tfstate
+*.tfstate.*
+.terraform/
+.terraform.lock.hcl
+*.tfvars
+!terraform.tfvars.example

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,5 +16,25 @@ services:
       timeout: 5s
       retries: 5
 
+  # Run app in container for local/prod parity
+  # Usage: docker-compose --profile app up
+  app:
+    build: .
+    container_name: quotewatch-app
+    ports:
+      - "8050:8050"
+    environment:
+      - PORT=8050
+      - ENABLE_PERSISTENCE=true
+      - ICEBERG_CATALOG_URI=postgresql+psycopg2://postgres:localdev@postgres:5432/iceberg
+      - ICEBERG_WAREHOUSE=file:///data/warehouse
+    volumes:
+      - ./data:/data
+    depends_on:
+      postgres:
+        condition: service_healthy
+    profiles:
+      - app
+
 volumes:
   postgres_data:

--- a/functions/expire_snapshots/main.py
+++ b/functions/expire_snapshots/main.py
@@ -1,0 +1,97 @@
+"""Cloud Function to expire old Iceberg snapshots.
+
+Triggered weekly by Cloud Scheduler to prevent unbounded storage growth.
+"""
+
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+
+import functions_framework
+from pyiceberg.catalog.sql import SqlCatalog
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+NAMESPACE = "quotewatch"
+TABLE_NAMES = ["raw_orderbook", "raw_trades", "features", "predictions"]
+RETENTION_DAYS = 30
+
+
+def get_catalog() -> SqlCatalog:
+    """Load Iceberg catalog from environment variables."""
+    catalog_uri = os.environ.get("ICEBERG_CATALOG_URI")
+    warehouse = os.environ.get("ICEBERG_WAREHOUSE")
+
+    if not catalog_uri:
+        raise ValueError("ICEBERG_CATALOG_URI environment variable is required")
+    if not warehouse:
+        raise ValueError("ICEBERG_WAREHOUSE environment variable is required")
+
+    return SqlCatalog(
+        "default",
+        uri=catalog_uri,
+        warehouse=warehouse,
+    )
+
+
+@functions_framework.http
+def expire_snapshots(request):
+    """HTTP Cloud Function to expire old Iceberg snapshots.
+
+    Args:
+        request: The request object (unused, but required by functions_framework).
+
+    Returns:
+        Tuple of (response body, status code).
+    """
+    logger.info(f"Starting snapshot expiration (retention: {RETENTION_DAYS} days)")
+
+    try:
+        catalog = get_catalog()
+    except Exception as e:
+        logger.error(f"Failed to connect to catalog: {e}")
+        return f"Failed to connect to catalog: {e}", 500
+
+    cutoff = datetime.now(UTC) - timedelta(days=RETENTION_DAYS)
+    cutoff_ms = int(cutoff.timestamp() * 1000)
+
+    results = {}
+
+    for table_name in TABLE_NAMES:
+        table_id = f"{NAMESPACE}.{table_name}"
+        try:
+            table = catalog.load_table(table_id)
+        except Exception as e:
+            logger.warning(f"Could not load table {table_id}: {e}")
+            results[table_name] = {"status": "skipped", "reason": str(e)}
+            continue
+
+        # Count snapshots before expiration
+        snapshots_before = list(table.metadata.snapshots)
+        old_snapshots = [s for s in snapshots_before if s.timestamp_ms < cutoff_ms]
+
+        if not old_snapshots:
+            logger.info(f"{table_name}: No snapshots older than {RETENTION_DAYS} days")
+            results[table_name] = {"status": "ok", "expired": 0}
+            continue
+
+        logger.info(
+            f"{table_name}: Expiring {len(old_snapshots)} snapshots "
+            f"older than {RETENTION_DAYS} days..."
+        )
+
+        try:
+            table.manage_snapshots().expire_snapshots_older_than(cutoff_ms).commit()
+            results[table_name] = {"status": "ok", "expired": len(old_snapshots)}
+            logger.info(f"{table_name}: Expired {len(old_snapshots)} snapshots")
+        except Exception as e:
+            logger.error(f"{table_name}: Failed to expire snapshots: {e}")
+            results[table_name] = {"status": "error", "reason": str(e)}
+
+    total_expired = sum(
+        r.get("expired", 0) for r in results.values() if isinstance(r, dict)
+    )
+    logger.info(f"Completed. Total snapshots expired: {total_expired}")
+
+    return {"status": "ok", "results": results, "total_expired": total_expired}, 200

--- a/functions/expire_snapshots/requirements.txt
+++ b/functions/expire_snapshots/requirements.txt
@@ -1,0 +1,4 @@
+functions-framework==3.*
+pyiceberg[sql-postgres]>=0.7.0
+psycopg2-binary>=2.9
+gcsfs>=2024.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "gunicorn>=21.0",
     "pyiceberg[sql-postgres]>=0.7.0",
     "psycopg2-binary>=2.9",
+    "gcsfs>=2024.2.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/expire_snapshots.py
+++ b/scripts/expire_snapshots.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Expire old Iceberg snapshots to reclaim storage.
+
+This script expires snapshots older than a threshold and removes orphan files.
+Run periodically (e.g., weekly via Cloud Scheduler) to prevent unbounded storage growth.
+
+Usage:
+    python scripts/expire_snapshots.py [--days 7] [--dry-run]
+
+Environment variables:
+    ICEBERG_CATALOG_URI: PostgreSQL connection string for Iceberg catalog
+    ICEBERG_WAREHOUSE: Warehouse path (gs://... or file://...)
+"""
+
+import argparse
+import logging
+import sys
+from datetime import UTC, datetime, timedelta
+
+from src.storage.catalog import get_catalog
+from src.storage.schemas import NAMESPACE
+
+TABLE_NAMES = ["raw_orderbook", "raw_trades", "features", "predictions"]
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def expire_snapshots(days: int = 7, dry_run: bool = False) -> dict[str, int]:
+    """Expire snapshots older than the specified number of days.
+
+    Args:
+        days: Number of days to retain snapshots. Older snapshots are expired.
+        dry_run: If True, only log what would be done without making changes.
+
+    Returns:
+        Dictionary mapping table names to number of snapshots expired.
+    """
+    catalog = get_catalog()
+    cutoff = datetime.now(UTC) - timedelta(days=days)
+    cutoff_ms = int(cutoff.timestamp() * 1000)
+
+    results = {}
+
+    for table_name in TABLE_NAMES:
+        table_id = f"{NAMESPACE}.{table_name}"
+        try:
+            table = catalog.load_table(table_id)
+        except Exception as e:
+            logger.warning(f"Could not load table {table_id}: {e}")
+            results[table_name] = 0
+            continue
+
+        # Count snapshots before expiration
+        snapshots_before = list(table.metadata.snapshots)
+        old_snapshots = [s for s in snapshots_before if s.timestamp_ms < cutoff_ms]
+
+        if not old_snapshots:
+            logger.info(f"{table_name}: No snapshots older than {days} days")
+            results[table_name] = 0
+            continue
+
+        if dry_run:
+            logger.info(
+                f"{table_name}: Would expire {len(old_snapshots)} snapshots "
+                f"(keeping {len(snapshots_before) - len(old_snapshots)})"
+            )
+            results[table_name] = len(old_snapshots)
+            continue
+
+        # Expire old snapshots
+        logger.info(
+            f"{table_name}: Expiring {len(old_snapshots)} snapshots "
+            f"older than {days} days..."
+        )
+
+        try:
+            # PyIceberg's expire_snapshots API
+            table.manage_snapshots().expire_snapshots_older_than(cutoff_ms).commit()
+            results[table_name] = len(old_snapshots)
+            logger.info(f"{table_name}: Expired {len(old_snapshots)} snapshots")
+        except Exception as e:
+            logger.error(f"{table_name}: Failed to expire snapshots: {e}")
+            results[table_name] = 0
+
+    return results
+
+
+def main() -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Expire old Iceberg snapshots to reclaim storage."
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=30,
+        help="Number of days to retain snapshots (default: 30)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Only log what would be done, don't make changes",
+    )
+    args = parser.parse_args()
+
+    logger.info(f"Expiring snapshots older than {args.days} days")
+    if args.dry_run:
+        logger.info("DRY RUN MODE - no changes will be made")
+
+    try:
+        results = expire_snapshots(days=args.days, dry_run=args.dry_run)
+    except Exception as e:
+        logger.error(f"Failed to expire snapshots: {e}")
+        return 1
+
+    total_expired = sum(results.values())
+    logger.info(f"Total snapshots expired: {total_expired}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,63 @@
+# Terraform Infrastructure
+
+Provisions GCP resources for QuoteWatch production data persistence.
+
+## Resources Created
+
+| Resource | Purpose |
+|----------|---------|
+| GCS bucket `quotewatch-data` | Iceberg warehouse (Parquet files) |
+| Cloud SQL Postgres `quotewatch-iceberg` | Iceberg catalog metadata |
+| Secret Manager `iceberg-catalog-uri` | Database connection string |
+| IAM bindings | Cloud Run access to storage, database, secrets |
+
+## Prerequisites
+
+1. Install Terraform >= 1.0
+2. Authenticate to GCP: `gcloud auth application-default login`
+3. Ensure you have `Owner` or equivalent permissions on `quotewatch-prod`
+
+## Usage
+
+```bash
+cd terraform
+
+# Initialize Terraform
+terraform init
+
+# Preview changes
+terraform plan
+
+# Apply changes
+terraform apply
+
+# View outputs (needed for CI/CD config)
+terraform output
+```
+
+## Outputs
+
+After applying, you'll need these values:
+
+| Output | Used for |
+|--------|----------|
+| `cloudsql_connection_name` | `--add-cloudsql-instances` flag in deploy |
+| `secret_name` | `--set-secrets` flag in deploy |
+| `warehouse_uri` | `ICEBERG_WAREHOUSE` env var |
+
+## Destroying Resources
+
+To tear down infrastructure (data will be lost!):
+
+```bash
+# First, disable deletion protection on Cloud SQL
+# Edit main.tf: deletion_protection = false
+terraform apply
+
+# Then destroy
+terraform destroy
+```
+
+## State Management
+
+State is stored locally in `terraform.tfstate` (gitignored). Keep this file safe - losing it means Terraform can't manage existing resources.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,236 @@
+# Terraform configuration for QuoteWatch production infrastructure
+#
+# This provisions:
+# - GCS bucket for Iceberg warehouse (Parquet files)
+# - Cloud SQL Postgres instance for Iceberg catalog
+# - Secret Manager secret for database connection string
+# - IAM bindings for Cloud Run service account
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+# -----------------------------------------------------------------------------
+# GCS Bucket for Iceberg Warehouse
+# -----------------------------------------------------------------------------
+
+resource "google_storage_bucket" "warehouse" {
+  name          = var.warehouse_bucket_name
+  location      = var.region
+  storage_class = "STANDARD"
+
+  # Prevent accidental deletion of data
+  force_destroy = false
+
+  # Enable versioning for safety (can recover deleted files)
+  versioning {
+    enabled = true
+  }
+
+  # Uniform bucket-level access (recommended)
+  uniform_bucket_level_access = true
+
+  labels = {
+    environment = "production"
+    app         = "quotewatch"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Cloud SQL Postgres Instance for Iceberg Catalog
+# -----------------------------------------------------------------------------
+
+resource "google_sql_database_instance" "iceberg_catalog" {
+  name             = var.cloudsql_instance_name
+  database_version = "POSTGRES_16"
+  region           = var.region
+
+  # Wait for SQL Admin API to be enabled
+  depends_on = [google_project_service.sqladmin]
+
+  # Deletion protection - set to false only when destroying
+  deletion_protection = true
+
+  settings {
+    tier = "db-f1-micro"
+
+    # Public IP enabled but locked down - no authorized networks
+    # Cloud Run connects via Unix socket at /cloudsql/CONNECTION_NAME
+    # This goes through Google's internal network, not the public internet
+    ip_configuration {
+      ipv4_enabled = true
+      # No authorized_networks = locked down, only Unix socket access
+    }
+
+    backup_configuration {
+      enabled    = true
+      start_time = "03:00" # 3 AM UTC
+    }
+
+    database_flags {
+      name  = "max_connections"
+      value = "50"
+    }
+
+    user_labels = {
+      environment = "production"
+      app         = "quotewatch"
+    }
+  }
+}
+
+# Database for Iceberg metadata
+resource "google_sql_database" "iceberg" {
+  name     = "iceberg"
+  instance = google_sql_database_instance.iceberg_catalog.name
+}
+
+# Generate random password for iceberg user
+resource "random_password" "iceberg_password" {
+  length  = 32
+  special = false # Avoid special chars that cause connection string issues
+}
+
+# Dedicated user for Iceberg catalog
+resource "google_sql_user" "iceberg" {
+  name     = "iceberg"
+  instance = google_sql_database_instance.iceberg_catalog.name
+  password = random_password.iceberg_password.result
+}
+
+# -----------------------------------------------------------------------------
+# Secret Manager - Database Connection String
+# -----------------------------------------------------------------------------
+
+resource "google_secret_manager_secret" "iceberg_catalog_uri" {
+  secret_id = "iceberg-catalog-uri"
+
+  # Wait for Secret Manager API to be enabled
+  depends_on = [google_project_service.secretmanager]
+
+  replication {
+    auto {}
+  }
+
+  labels = {
+    environment = "production"
+    app         = "quotewatch"
+  }
+}
+
+# The connection string uses Unix socket path for Cloud Run
+# Format: postgresql+psycopg2://user:pass@/database?host=/cloudsql/CONNECTION_NAME
+resource "google_secret_manager_secret_version" "iceberg_catalog_uri" {
+  secret = google_secret_manager_secret.iceberg_catalog_uri.id
+  secret_data = "postgresql+psycopg2://${google_sql_user.iceberg.name}:${random_password.iceberg_password.result}@/${google_sql_database.iceberg.name}?host=/cloudsql/${google_sql_database_instance.iceberg_catalog.connection_name}"
+}
+
+# -----------------------------------------------------------------------------
+# IAM Bindings for Cloud Run Service Account
+# -----------------------------------------------------------------------------
+
+# Get project info to construct default service account email
+data "google_project" "current" {
+}
+
+# Default compute service account: PROJECT_NUMBER-compute@developer.gserviceaccount.com
+locals {
+  compute_service_account = "${data.google_project.current.number}-compute@developer.gserviceaccount.com"
+}
+
+# Cloud Run needs access to GCS bucket
+resource "google_storage_bucket_iam_member" "cloud_run_storage" {
+  bucket = google_storage_bucket.warehouse.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${local.compute_service_account}"
+}
+
+# Cloud Run needs access to Cloud SQL
+resource "google_project_iam_member" "cloud_run_cloudsql" {
+  project = var.project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${local.compute_service_account}"
+}
+
+# Cloud Run needs access to secrets
+resource "google_secret_manager_secret_iam_member" "cloud_run_secret_access" {
+  secret_id = google_secret_manager_secret.iceberg_catalog_uri.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${local.compute_service_account}"
+}
+
+# -----------------------------------------------------------------------------
+# Enable Required APIs
+# -----------------------------------------------------------------------------
+
+resource "google_project_service" "sqladmin" {
+  service            = "sqladmin.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "secretmanager" {
+  service            = "secretmanager.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "cloudscheduler" {
+  service            = "cloudscheduler.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "cloudfunctions" {
+  service            = "cloudfunctions.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "cloudbuild" {
+  service            = "cloudbuild.googleapis.com"
+  disable_on_destroy = false
+}
+
+# -----------------------------------------------------------------------------
+# Cloud Function for Snapshot Expiration
+# -----------------------------------------------------------------------------
+#
+# The Cloud Function is deployed automatically via CI on merge to main.
+# See .github/workflows/ci.yml for the deploy step.
+# Source code: functions/expire_snapshots/
+
+# Cloud Scheduler job to trigger expiration weekly
+resource "google_cloud_scheduler_job" "expire_snapshots" {
+  name      = "expire-snapshots-weekly"
+  region    = var.region
+  schedule  = "0 4 * * 0" # 4 AM UTC every Sunday
+  time_zone = "UTC"
+
+  depends_on = [google_project_service.cloudscheduler]
+
+  http_target {
+    uri         = "https://${var.region}-${var.project_id}.cloudfunctions.net/expire-snapshots"
+    http_method = "POST"
+
+    oidc_token {
+      service_account_email = local.compute_service_account
+    }
+  }
+
+  retry_config {
+    retry_count = 1
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,28 @@
+# Outputs for QuoteWatch infrastructure
+#
+# These values are needed to configure the application and CI/CD pipeline.
+
+output "warehouse_bucket" {
+  description = "GCS bucket name for Iceberg warehouse"
+  value       = google_storage_bucket.warehouse.name
+}
+
+output "warehouse_uri" {
+  description = "GCS URI for Iceberg warehouse (use as ICEBERG_WAREHOUSE)"
+  value       = "gs://${google_storage_bucket.warehouse.name}/warehouse"
+}
+
+output "cloudsql_connection_name" {
+  description = "Cloud SQL connection name (for --add-cloudsql-instances flag)"
+  value       = google_sql_database_instance.iceberg_catalog.connection_name
+}
+
+output "secret_name" {
+  description = "Secret Manager secret name for catalog URI"
+  value       = google_secret_manager_secret.iceberg_catalog_uri.secret_id
+}
+
+output "secret_version" {
+  description = "Full path to latest secret version (for Cloud Run)"
+  value       = "${google_secret_manager_secret.iceberg_catalog_uri.name}/versions/latest"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,25 @@
+# Input variables for QuoteWatch infrastructure
+
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+  default     = "quotewatch-prod"
+}
+
+variable "region" {
+  description = "GCP region for resources"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "warehouse_bucket_name" {
+  description = "Name of GCS bucket for Iceberg warehouse"
+  type        = string
+  default     = "quotewatch-data"
+}
+
+variable "cloudsql_instance_name" {
+  description = "Name of Cloud SQL instance for Iceberg catalog"
+  type        = string
+  default     = "quotewatch-iceberg"
+}


### PR DESCRIPTION
## Summary

- Add Terraform configuration for production infrastructure (GCS bucket, Cloud SQL Postgres, Secret Manager, IAM bindings)
- Add Cloud Function + Cloud Scheduler for automated weekly snapshot expiration (30-day retention)
- Update CI/CD workflow to deploy Cloud Function and Cloud Run with persistence configuration
- Add docker-compose app service for local/production parity
- Add `gcsfs` dependency for GCS filesystem support

## Production Infrastructure

| Resource | Description |
|----------|-------------|
| GCS Bucket | `gs://quotewatch-data/warehouse` - Iceberg Parquet files |
| Cloud SQL | `quotewatch-iceberg` - Postgres 16 for Iceberg catalog |
| Secret | `iceberg-catalog-uri` - Database connection string |
| Cloud Function | `expire-snapshots` - Weekly snapshot expiration |
| Cloud Scheduler | `expire-snapshots-weekly` - Triggers function at 4 AM UTC Sundays |

## Test plan

- [x] Terraform applied successfully (`terraform apply`)
- [x] GCS bucket created and accessible
- [x] Cloud SQL instance running with database and user
- [x] Secret Manager secret created with connection string
- [x] IAM bindings configured for compute service account
- [x] Cloud Scheduler job created
- [ ] CI/CD deploys Cloud Function on merge
- [ ] CI/CD deploys Cloud Run with persistence config on merge
- [ ] Verify data persistence after deployment

Closes #51