### PR TITLE
docs: update architecture and design docs for epic #35 completion

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -229,7 +229,6 @@ stateDiagram-v2
 
 - WebSocket-based dashboard (replace polling with push)
 - Multi-symbol support (ETH-USD, SOL-USD)
-- GCS backend for production (Cloud SQL Postgres + GCS warehouse)
 - Offline training pipeline (using DataReader for historical replay)
 - Model hot-reload
 - Kubernetes deployment for horizontal scaling

--- a/docs/design/data-layer.md
+++ b/docs/design/data-layer.md
@@ -69,7 +69,7 @@ flowchart TB
 
     subgraph Ingestion["Ingestion Layer"]
         WSClient[WebSocketClient]
-        OB[OrderBook<br/>depth=20]
+        OB[OrderBook<br/>depth=10]
         TB[TradeBuffer]
     end
 


### PR DESCRIPTION
## Summary

- Remove GCS backend from Future Improvements in architecture.md (now implemented)
- Fix target state diagram in data-layer.md to show depth=10 (matches implementation)

Closes the documentation step for epic #35.